### PR TITLE
sha: fix strict aliasing warnings

### DIFF
--- a/crypto/sha256.c
+++ b/crypto/sha256.c
@@ -495,7 +495,7 @@ SHA256_Final(u_int8_t digest[], SHA256_CTX *context)
    *context->buffer = 0x80;
   }
   /* Set the bit count: */
-  *(u_int64_t *)&context->buffer[SHA256_SHORT_BLOCK_LENGTH] = context->bitcount;
+  memcpy (&context->buffer[SHA256_SHORT_BLOCK_LENGTH], &context->bitcount, 8);
 
   /* Final transform: */
   SHA256_Transform(context, context->buffer);
@@ -787,8 +787,8 @@ SHA512_Last(SHA512_CTX *context)
   *context->buffer = 0x80;
  }
  /* Store the length of input data (in bits): */
- *(u_int64_t *)&context->buffer[SHA512_SHORT_BLOCK_LENGTH] = context->bitcount[1];
- *(u_int64_t *)&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8] = context->bitcount[0];
+ memcpy (&context->buffer[SHA512_SHORT_BLOCK_LENGTH], &context->bitcount[1], 8);
+ memcpy (&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8], &context->bitcount[0], 8);
 
  /* Final transform: */
  SHA512_Transform(context, context->buffer);


### PR DESCRIPTION
sha256.c:492:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
sha256.c:784:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
sha256.c:785:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]

Signed-off-by: Mike Frysinger vapier@gentoo.org
