### PR TITLE
Issue #94: Changed thread start logic in cckddasd.c to eliminate runaways

### DIFF
--- a/cckddasd.c
+++ b/cckddasd.c
@@ -356,7 +356,8 @@ int             fdflags;                /* File flags                */
     cckd_unlock_devchain();
 
     cckdblk.batch = dev->batch;
-    if (cckdblk.batch)
+	
+	if (cckdblk.batch)
     {
         cckdblk.nostress = 1;
         cckdblk.freepend = 0;
@@ -1508,17 +1509,23 @@ int             rc;
     }
 
     /* Schedule the readahead if any are pending */
-    if (cckdblk.ra1st >= 0)
-    {
-        if (cckdblk.rawaiting)
-            signal_condition (&cckdblk.racond);
-        else if (cckdblk.ras < cckdblk.ramax)
-        {
-            rc = create_thread (&tid, JOINABLE, cckd_ra, NULL, "cckd_ra");
-            if (rc)
-                WRMSG(HHC00102, "E", strerror(rc));
-        }
-    }
+	if (cckdblk.ra1st >= 0)
+		if (cckdblk.rawaiting)
+			signal_condition(&cckdblk.racond);
+		else if (cckdblk.ras < cckdblk.ramax)   /* Schedule a new read-ahead thread  */
+		{
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+				WRMSG(HHC00107, "I", "cckd_ra()", cckdblk.raa, cckdblk.ras, cckdblk.ramax);
+			++cckdblk.ras;
+			release_lock(&cckdblk.ralock);  /* release lock across thread create to prevent interlock  */
+			rc = create_thread(&tid, JOINABLE, cckd_ra, NULL, "cckd_ra");
+			obtain_lock(&cckdblk.ralock);
+			if (rc)
+			{
+				WRMSG(HHC00106, "E", "cckd_ra()", cckdblk.ras-1, cckdblk.ramax, strerror(rc));
+				--cckdblk.ras;
+			}
+		}
 
     release_lock (&cckdblk.ralock);
 
@@ -1550,35 +1557,43 @@ int             k;                      /* Index                     */
 /*-------------------------------------------------------------------*/
 void* cckd_ra (void* arg)
 {
-CCKDDASD_EXT   *cckd;                   /* -> cckd extension         */
-DEVBLK         *dev;                    /* Readahead devblk          */
-int             trk;                    /* Readahead track           */
-int             ra;                     /* Readahead index           */
-int             r;                      /* Readahead queue index     */
-TID             tid;                    /* Readahead thread id       */
-char            threadname[40];
-int             rc;
+	CCKDDASD_EXT   *cckd;                   /* -> cckd extension         */
+	DEVBLK         *dev;                    /* Readahead devblk          */
+	int             trk;                    /* Readahead track           */
+	int             ra;                     /* Readahead index           */
+	int             r;                      /* Readahead queue index     */
+	TID             tid;                    /* Readahead thread id       */
+	char            threadname[40];
+	int             rc;
 
-    UNREFERENCED( arg );
+	UNREFERENCED(arg);
 
-    obtain_lock (&cckdblk.ralock);
-    ra = ++cckdblk.ras;
+	obtain_lock(&cckdblk.ralock);
+	ra = ++cckdblk.raa;  /* increment nr ra threads dispatched */
+	MSGBUF(threadname, "Read-ahead thread-%d", ra);
 
-    /* Return without messages if too many already started */
-    if (ra > cckdblk.ramax)
-    {
-        --cckdblk.ras;
-        release_lock (&cckdblk.ralock);
-        return NULL;
-    }
+	/* Return if too many already started */
+	if (ra > cckdblk.ramax)
+	{
+		--cckdblk.ras;  /* decrement count started */
+		--cckdblk.raa;  /* decrement count running */
+		if (!cckdblk.ramax)
+		{
+			signal_condition(&cckdblk.termcond);
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+				WRMSG(HHC00101, "I", thread_id(), get_thread_priority(0), threadname);
+		}
+		else
+			if (!cckdblk.batch || cckdblk.batchml > 0)
+				WRMSG(HHC00108, "W", thread_id(), threadname, get_thread_priority(0), ra, cckdblk.ramax);
+		release_lock(&cckdblk.ralock);
+		return NULL;
+	}
 
-    if (!cckdblk.batch)
-    {
-        MSGBUF( threadname, "Read-ahead thread-%d", ra);
+	if (!cckdblk.batch || cckdblk.batchml > 1)
         WRMSG (HHC00100, "I", thread_id(), get_thread_priority(0), threadname);
-    }
 
-    while (ra <= cckdblk.ramax)
+    while (ra <= cckdblk.ramax)   /* continue until ramax=0 (shutdown) or max reduced by command line */
     {
         if (cckdblk.ra1st < 0)
         {
@@ -1605,16 +1620,22 @@ int             rc;
 
         /* Schedule the other readaheads if any are still pending */
         if (cckdblk.ra1st)
-        {
-            if (cckdblk.rawaiting)
+			if (cckdblk.rawaiting)
                 signal_condition (&cckdblk.racond);
             else if (cckdblk.ras < cckdblk.ramax)
-            {
-                rc = create_thread (&tid, JOINABLE, cckd_ra, dev, "cckd_ra");
-                if (rc)
-                    WRMSG(HHC00102, "E", strerror(rc));
-            }
-        }
+			{
+				if (!cckdblk.batch || cckdblk.batchml > 1)
+					WRMSG(HHC00107, "I", "cckd_ra() from cckd_ra()", cckdblk.raa, cckdblk.ras, cckdblk.ramax);
+				++cckdblk.ras;
+				release_lock(&cckdblk.ralock);  /* release lock across thread create to prevent interlock  */
+				rc = create_thread(&tid, JOINABLE, cckd_ra, NULL, "cckd_ra");
+				obtain_lock(&cckdblk.ralock);
+				if (rc)
+				{
+					WRMSG(HHC00106, "E", "cckd_ra() from cckd_ra()", cckdblk.ras-1, cckdblk.ramax, strerror(rc));
+					--cckdblk.ras;
+				}
+			}
 
         if (!cckd || cckd->stopping || cckd->merging) continue;
 
@@ -1628,9 +1649,10 @@ int             rc;
         cckd->ras--;
     }
 
-    if (!cckdblk.batch)
+	if (!cckdblk.batch || cckdblk.batchml > 1)
         WRMSG (HHC00101, "I", thread_id(), get_thread_priority(0), threadname);
     --cckdblk.ras;
+	--cckdblk.raa;
     if (!cckdblk.ras) signal_condition(&cckdblk.termcond);
     release_lock(&cckdblk.ralock);
     return NULL;
@@ -1656,18 +1678,27 @@ TID             tid;                    /* Writer thread id          */
 
     /* Schedule the writer if any writes are pending */
     if (cckdblk.wrpending)
-    {
         if (cckdblk.wrwaiting)
             signal_condition (&cckdblk.wrcond);
         else if (cckdblk.wrs < cckdblk.wrmax)
         {
-            rc = create_thread (&tid, JOINABLE, cckd_writer, NULL, "cckd_writer");
-            if (rc)
-                WRMSG(HHC00102, "E", strerror(rc));
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+				WRMSG(HHC00107, "I", "cckd_writer()", cckdblk.wra, cckdblk.wrs, cckdblk.wrmax);
+			++cckdblk.wrs; 
+			release_lock(&cckdblk.wrlock);  /* release lock across thread create to prevent interlock  */
+			rc = create_thread(&tid, JOINABLE, cckd_writer, NULL, "cckd_writer");
+			obtain_lock(&cckdblk.wrlock);
+			if (rc)
+			{
+				WRMSG(HHC00106, "E", "cckd_writer()", cckdblk.wrs-1, cckdblk.wrmax, strerror(rc));
+				--cckdblk.wrs;
+			}
         }
-    }
-    release_lock (&cckdblk.wrlock);
+
+	release_lock (&cckdblk.wrlock);
 }
+
+
 int cckd_flush_cache_scan (int *answer, int ix, int i, void *data)
 {
 CCKDDASD_EXT   *cckd;                   /* -> cckd extension         */
@@ -1771,21 +1802,29 @@ int             rc;
 
     obtain_lock (&cckdblk.wrlock);
 
-    writer = ++cckdblk.wrs;
+    writer = ++cckdblk.wra;
+	MSGBUF(threadname, "Writer thread-%d", writer);
 
-    /* Return without messages if too many already started */
+    /* Return with message if too many already started */
     if (writer > cckdblk.wrmax)
     {
-        --cckdblk.wrs;
-        release_lock (&cckdblk.wrlock);
+        --cckdblk.wrs;  /* decrease threads started */
+		--cckdblk.wra;  /* decrease threads active  */
+		if (!cckdblk.wrmax)  /* choose thread termination message  */
+		{
+			signal_condition(&cckdblk.termcond);  /* shutting down */
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+			  WRMSG(HHC00101, "I", thread_id(), get_thread_priority(0), threadname);
+		}
+		else
+			if (!cckdblk.batch || cckdblk.batchml > 0)
+				WRMSG(HHC00108, "W", thread_id(), threadname, get_thread_priority(0), writer, cckdblk.wrmax);
+		release_lock (&cckdblk.wrlock);
         return NULL;
     }
 
-    if (!cckdblk.batch)
-    {
-        MSGBUF( threadname, "Writer thread-%d", writer);
-        WRMSG ( HHC00100, "I", thread_id(), get_thread_priority(0), threadname);
-    }
+	if (!cckdblk.batch || cckdblk.batchml > 1)
+		WRMSG ( HHC00100, "I", thread_id(), get_thread_priority(0), threadname);
 
     while (writer <= cckdblk.wrmax || cckdblk.wrpending)
     {
@@ -1814,17 +1853,24 @@ int             rc;
         /* Schedule the other writers if any writes are still pending */
         cckdblk.wrpending--;
         if (cckdblk.wrpending)
-        {
             if (cckdblk.wrwaiting)
                 signal_condition (&cckdblk.wrcond);
             else if (cckdblk.wrs < cckdblk.wrmax)
             {
-                rc = create_thread (&tid, JOINABLE, cckd_writer, NULL, "cckd_writer");
-                if (rc)
-                    WRMSG(HHC00102, "E", strerror(rc));
+				if (!cckdblk.batch || cckdblk.batchml > 1)
+					WRMSG(HHC00107, "I", "cckd_writer() from cckd_writer()", cckdblk.wra, cckdblk.wrs, cckdblk.wrmax);
+				++cckdblk.wrs;
+				release_lock(&cckdblk.wrlock);  /* release lock across thread create to prevent interlock  */
+				rc = create_thread(&tid, JOINABLE, cckd_writer, NULL, "cckd_writer");
+				obtain_lock(&cckdblk.wrlock);
+				if (rc)
+				{
+					WRMSG(HHC00106, "E", "cckd_writer() from cckd_writer()", cckdblk.wrs-1, cckdblk.wrmax, strerror(rc));
+					--cckdblk.wrs;
+				}
             }
-        }
-        release_lock (&cckdblk.wrlock);
+        
+		release_lock (&cckdblk.wrlock);
 
         /* Prepare to compress */
         CCKD_CACHE_GETKEY(o, devnum, trk);
@@ -1885,12 +1931,24 @@ int             rc;
         release_lock (&cckd->filelock);
 
         /* Schedule the garbage collector */
-        if (cckdblk.gcs < cckdblk.gcmax)
-        {
-            rc = create_thread (&tid, JOINABLE, cckd_gcol, NULL, "cckd_gcol");
-            if (rc)
-                WRMSG(HHC00102, "E", strerror(rc));
-        }
+		obtain_lock(&cckdblk.gclock);  /* ensure read integrity for gc count */
+		if (cckdblk.gcs < cckdblk.gcmax)
+		{
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+				WRMSG(HHC00107, "I", "cckd_gcol()", cckdblk.gca, cckdblk.gcs, cckdblk.gcmax);
+			++cckdblk.gcs;
+			release_lock(&cckdblk.gclock);  /* release lock across thread create to prevent interlock  */
+			rc = create_thread(&tid, JOINABLE, cckd_gcol, NULL, "cckd_gcol");
+			if (rc)
+			{
+				WRMSG(HHC00106, "E", "cckd_gcol()", cckdblk.gcs-1, cckdblk.gcmax, strerror(rc));
+				obtain_lock(&cckdblk.gclock);
+				--cckdblk.gcs;
+				release_lock(&cckdblk.gclock);
+			}
+		}
+		else
+			release_lock(&cckdblk.gclock);
 
         obtain_lock (&cckd->cckdiolock);
         cache_lock (CACHE_DEVBUF);
@@ -1910,9 +1968,10 @@ int             rc;
         obtain_lock(&cckdblk.wrlock);
     }
 
-    if (!cckdblk.batch)
+	if (!cckdblk.batch || cckdblk.batchml > 1)
         WRMSG (HHC00101, "I", thread_id(), get_thread_priority(0), threadname);
     cckdblk.wrs--;
+	cckdblk.wra--;
     if (cckdblk.wrs == 0) signal_condition(&cckdblk.termcond);
     release_lock(&cckdblk.wrlock);
     return NULL;
@@ -4613,6 +4672,14 @@ void cckd_unlock_devchain()
 
 /*-------------------------------------------------------------------*/
 /* Garbage Collection thread                                         */
+/*																	 */
+/*	While provision is made in the code that initiates cckd_gcol	 */
+/*	for execution of more than one concurrent Garbage Collector,	 */
+/*	the thread runs with mutex cckdblk.gclock held at all times		 */
+/*	and is therefore limited to one concurrent thread.  We'll leave	 */
+/*	the initiation code as-is in anticipation of the day when we 	 */
+/*	might get to a max of one collector per compressed device.		 */
+/*																	 */
 /*-------------------------------------------------------------------*/
 void* cckd_gcol(void* arg)
 {
@@ -4637,24 +4704,32 @@ int             gctab[5]= {             /* default gcol parameters   */
     gettimeofday (&tv_now, NULL);
 
     obtain_lock (&cckdblk.gclock);
-    gcol = ++cckdblk.gcs;
+    gcol = ++cckdblk.gca;
 
     /* Return without messages if too many already started */
     if (gcol > cckdblk.gcmax)
     {
-        --cckdblk.gcs;
-        release_lock (&cckdblk.gclock);
-        return NULL;
+		--cckdblk.gcs;
+		--cckdblk.gca;
+		if (!cckdblk.gcs)
+		{
+			signal_condition(&cckdblk.termcond);  /* signal if last gcol thread ending before init. */
+			if (!cckdblk.batch || cckdblk.batchml > 1)
+				WRMSG(HHC00101, "I", thread_id(), get_thread_priority(0), "Garbage collector");
+		}
+		else
+			if (!cckdblk.batch || cckdblk.batchml > 0)
+				WRMSG(HHC00108, "W", thread_id(), "cckd_gcol()", get_thread_priority(0), cckdblk.gcs, cckdblk.gcmax);
+		release_lock (&cckdblk.gclock);
+        return NULL;		/* back to the shadows again  */
     }
 
-    if (!cckdblk.batch)
-    {
-        WRMSG (HHC00100, "I", thread_id(), get_thread_priority(0), "Garbage collector");
-    }
+	if (!cckdblk.batch || cckdblk.batchml > 1)
+		WRMSG (HHC00100, "I", thread_id(), get_thread_priority(0), "Garbage collector");
 
     while (gcol <= cckdblk.gcmax)
     {
-        cckd_lock_devchain(0);
+		cckd_lock_devchain(0);
         /* Perform collection on each device */
         for (dev = cckdblk.dev1st; dev; dev = cckd->devnext)
         {
@@ -4759,10 +4834,11 @@ int             gctab[5]= {             /* default gcol parameters   */
         timed_wait_condition (&cckdblk.gccond, &cckdblk.gclock, &tm);
     }
 
-    if (!cckdblk.batch)
-    WRMSG (HHC00101, "I", thread_id(), get_thread_priority(0), "Garbage collector");
+	if (!cckdblk.batch || cckdblk.batchml > 1)
+	    WRMSG (HHC00101, "I", thread_id(), get_thread_priority(0), "Garbage collector");
 
     cckdblk.gcs--;
+	cckdblk.gca--;
     if (!cckdblk.gcs) signal_condition (&cckdblk.termcond);
     release_lock (&cckdblk.gclock);
     return NULL;
@@ -5831,11 +5907,26 @@ int   rc;
                     release_lock (&cckd->filelock);
                 }
                 cckd_unlock_devchain();
-                if (flag && cckdblk.gcs < cckdblk.gcmax)
+                if (flag && cckdblk.gcs < cckdblk.gcmax)  /* Schedule the garbage collector */
                 {
-                    rc = create_thread (&tid, JOINABLE, cckd_gcol, NULL, "cckd_gcol");
-                    if (rc)
-                        WRMSG(HHC00102, "E", strerror(rc));
+					obtain_lock(&cckdblk.gclock);  /* ensure read integrity for gc count */
+					if (cckdblk.gcs < cckdblk.gcmax)
+					{
+						if (!cckdblk.batch || cckdblk.batchml > 1)
+							WRMSG(HHC00107, "I", "cckd_gcol() by command line", cckdblk.gca, cckdblk.gcs, cckdblk.gcmax);
+						++cckdblk.gcs;
+						release_lock(&cckdblk.gclock);  /* release lock across thread create to prevent interlock  */
+						rc = create_thread(&tid, JOINABLE, cckd_gcol, NULL, "cckd_gcol");
+						if (rc)
+						{
+							WRMSG(HHC00106, "E", "cckd_gcol() by command line", cckdblk.gcs-1, cckdblk.gcmax, strerror(rc));
+							obtain_lock(&cckdblk.gclock);
+							--cckdblk.gcs;
+							release_lock(&cckdblk.gclock);
+						}
+					}
+					else
+						release_lock(&cckdblk.gclock);
                 }
             }
         }

--- a/dasdload.c
+++ b/dasdload.c
@@ -4441,6 +4441,9 @@ char           *strtok_str = NULL;      /* last token position       */
         return -1;
     }
 
+	if (cif->devblk.cckd_ext)        /* have a compressed ckd extension?  */
+		cckdblk.batchml = infolvl;   /* yes, save message level in cckdblk for cckddasd   */
+	
     /* Display progress message */
     XMINFF (0, MSG( HHC02521, "I", devtype, volser ) );
 

--- a/hstructs.h
+++ b/hstructs.h
@@ -1765,6 +1765,7 @@ struct CCKDBLK {                        /* Global cckd dasd block    */
                          sfmerge:1,     /* 1=sf-* merge              */
                          sfforce:1;     /* 1=sf-* force              */
         int              sflevel;       /* sfk xxxx level            */
+		int				 batchml;       /* message level for batch ops  */
 
         BYTE             comps;         /* Supported compressions    */
         BYTE             comp;          /* Override compression      */
@@ -1772,7 +1773,8 @@ struct CCKDBLK {                        /* Global cckd dasd block    */
 
         LOCK             gclock;        /* Garbage collector lock    */
         COND             gccond;        /* Garbage collector cond    */
-        int              gcs;           /* Number garbage collectors */
+        int              gcs;           /* Number garbage collector threads started */
+		int				 gca;           /* Number garbage collector threads active */
         int              gcmax;         /* Max garbage collectors    */
         int              gcwait;        /* Wait time in seconds      */
         int              gcparm;        /* Adjustment parm           */
@@ -1781,13 +1783,15 @@ struct CCKDBLK {                        /* Global cckd dasd block    */
         COND             wrcond;        /* I/O condition             */
         int              wrpending;     /* Number writes pending     */
         int              wrwaiting;     /* Number writers waiting    */
-        int              wrs;           /* Number writer threads     */
+        int              wrs;           /* Number writer threads started  */
+		int				 wra;           /* Number writer threads active  */
         int              wrmax;         /* Max writer threads        */
         int              wrprio;        /* Writer thread priority    */
 
         LOCK             ralock;        /* Readahead lock            */
         COND             racond;        /* Readahead condition       */
-        int              ras;           /* Number readahead threads  */
+        int              ras;           /* Number readahead threads started */
+		int				 raa;           /* Number readadead threads active */
         int              ramax;         /* Max readahead threads     */
         int              rawaiting;     /* Number threads waiting    */
         int              ranbr;         /* Readahead queue size      */

--- a/msgenu.h
+++ b/msgenu.h
@@ -306,6 +306,9 @@ Examples:
 #define HHC00102 "Error in function create_thread(): %s"
 #define HHC00103 "Thread id "TIDPAT" name %s, priority change: old %2d, new %2d"
 #define HHC00105 "Thread id "TIDPAT" name %s is still active"
+#define HHC00106 "Error in function create_thread() for %s %d of %d: %s"
+#define HHC00107 "Starting thread %s, active=%d, started=%d, max=%d"
+#define HHC00108 "Ending thread "TIDPAT" %s, pri=%d, started=%d, max=%d exceeded"
 // reserve 102-129 thread related
 #define HHC00130 "PGMPRDOS LICENSED specified and a licenced program product operating system is running"
 #define HHC00131 "A licensed program product operating system detected, all processors have been stopped"


### PR DESCRIPTION
Changed thread start logic for ra, writer & gcol threads to match that used in channel.c for device threads (increment count in main thread, decrement in started thread at thread exit).  Added support for dasdload message level in cckddasd. Added HHC00108W and HHC00107I messages; replaced HHC00102E with HH00106E to provide diagnostic info.