### PR TITLE
Changed process_dirblk() to explicitly set multitxt variable to 0 or 1.

### DIFF
--- a/dasdisup.c
+++ b/dasdisup.c
@@ -467,11 +467,11 @@ char            memnama[9];             /* Member name (ASCIIZ)      */
                                                                 1 : 0;
 
         /* Check that the member has a single text record */
-        if ((dirent->pds2usrd[8] & 0x01) == 0 || totlen != txtlen)
+		memtab[n].multitxt = ((dirent->pds2usrd[8] & 0x01) == 0 || totlen != txtlen) ? 1 : 0;
+		if (memtab[n].multitxt)
         {
             // "Member %s is not a single text record"
             FWRMSG( stderr, HHC02453, "W", memnama );
-            memtab[n].multitxt = 1;
         }
 
         /* Check that the total module length does not exceed X'7F8' */


### PR DESCRIPTION
Current code, extant since 2001, depends on malloc() returning a block initialized to zeros.  Builds performed using Visual Studio 2015 Community Edition do not fulfill this dependency, resulting in excess HHC02444E messages and incorrect TTR updates to SVCLIB.  And this means OS/360 cannot IPL the volume.  