### PR TITLE
Removed preprocessor variables V1, V2, V3, V4 from c code.

### DIFF
--- a/dyngui.c
+++ b/dyngui.c
@@ -15,12 +15,14 @@
 #include "devtype.h"
 #include "opcode.h"
 
+#if 0  /* pending removal of code for V1, V2, V3, & V4  */
 #if !defined(V1)
  #define V1 0
 #endif
 #if !defined(V2)
  #define V2 0
 #endif
+#endif  /* #if 0  ... pending removal of code for V1, V2, V3, & V4  */
 
 ///////////////////////////////////////////////////////////////////////////////
 // Some handy macros...       (feel free to add these to hercules.h)
@@ -463,7 +465,8 @@ void*  gui_panel_command (char* pszCommand)
         // future versions of HercGUI to know whether the version of Hercules
         // that it's talking to supports a given feature or not. Slick, eh? :)
 
-        // PROGRAMMING NOTE: we use 'V1' and 'V2' here (instead of 'VERSION')
+#if 0  /* pending removal of code for V1, V2, V3, & V4  */
+		// PROGRAMMING NOTE: we use 'V1' and 'V2' here (instead of 'VERSION')
         // since the 'VERSION' string can be any value the user wants and thus
         // might not be numeric nor even correspond at all to Hercules's actual
         // build version. V1 and V2 however should ALWAYS be numbers and should
@@ -478,6 +481,7 @@ void*  gui_panel_command (char* pszCommand)
         //  set in configure.ac by reasonable people it is SAFE to expect that
         //  it will always be a sequence of 2 digits numbers xx.xx.xx
         //  so instead of using %d,%d V1,V2 it is right to ....
+#endif  /* #if 0  ... pending removal of code for V1, V2, V3, & V4  */
 
         gui_fprintf(fStatusStream,"MAINSIZE=%s\n",VERSION);
 

--- a/msvc.makefile.includes/HERC_FLAGS.msvc
+++ b/msvc.makefile.includes/HERC_FLAGS.msvc
@@ -40,18 +40,19 @@ MAX_CPU_ENGINES = 8
 !ENDIF
 
 rcflags = $(rcflags) -D _MSVC_ -D "VERSION=$(VERSION)" -D V1=$(V1) -D V2=$(V2) -D V3=$(V3) -D V4=$(V4)
+cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
 
-!IF $(vsversion) >= $(vers_vs2015)
-
-#    FIXME:  MSVC version 19.00 (vs2015) uses V1-V2-V3-V4?!
-#            This needs confirmed/resolved!
-
-##cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
-cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" -D V1=$(V1) -D V2=$(V2) -D V3=$(V3) -D V4=$(V4) /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
-!ELSE
-cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" -D V1=$(V1) -D V2=$(V2) -D V3=$(V3) -D V4=$(V4) /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
-!ENDIF
-
+## Pending Removal ## !IF $(vsversion) >= $(vers_vs2015)
+## Pending Removal ## 
+## Pending Removal ## #    FIXME:  MSVC version 19.00 (vs2015) uses V1-V2-V3-V4?!
+## Pending Removal ## #            This needs confirmed/resolved!
+## Pending Removal ## 
+## Pending Removal ## ##cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
+## Pending Removal ## cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" -D V1=$(V1) -D V2=$(V2) -D V3=$(V3) -D V4=$(V4) /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
+## Pending Removal ## !ELSE
+## Pending Removal ## cflags  = $(cflags)  /D _MSVC_ /D "VERSION=$(VERSION)" -D V1=$(V1) -D V2=$(V2) -D V3=$(V3) -D V4=$(V4) /D MAX_CPU_ENGINES=$(MAX_CPU_ENGINES)
+## Pending Removal ## !ENDIF
+## Pending Removal ## 
 
 !IF DEFINED(CUSTOM_BUILD_STRING)
 cflags  = $(cflags)  /D CUSTOM_BUILD_STRING=\"$(CUSTOM_BUILD_STRING)\"

--- a/version.h
+++ b/version.h
@@ -27,6 +27,7 @@
 #define VER_DLL_IMPORT DLL_EXPORT
 #endif /* _LOGGER_C_ */
 
+#if 0  /* pending removal of code for V1, V2, V3, & V4  */
 #if !defined(VERSION)
 #if defined(V1) && defined(V2) && defined(V3) && defined(V4)
 #define VER V1##.##V2##.##V3##.##V4
@@ -56,13 +57,14 @@
 
   #endif
 #endif
+#endif  /* #if 0  ... pending removal of code for V1, V2, V3, & V4  */
 
 /*
   The 'VERSION' string can be any value the user wants.
 */
 #if !defined(VERSION)
   WARNING("No version specified")
-  #define VERSION              "(unknown!)"
+  #define VERSION              "0.0.0.0-(unknown!)"  /* ensure a numeric unknown version  */
   #define CUSTOM_BUILD_STRING  "('VERSION' was not defined!)"
 #endif
 


### PR DESCRIPTION
Addresses issue #102.  Removed preprocessor variables V1, V2, V3, V4 from C Compiler environment.  Eliminates collision with variable names V2, V3, and V4 defined in winioctl.h in Microsoft Windows SDK version 8.1 and above.  The variables remain in the Windows build scripts because the Windows Resource Compiler requires their values.   This commit should enable Windows builds on VS2008 -> VS2015.  