### PR TITLE
Make hyperion compile on NetBSD and with fewer warnings.

### DIFF
--- a/archlvl.c
+++ b/archlvl.c
@@ -682,7 +682,7 @@ BYTE als =
         set_facility(tb, enable, als );
     else
     if(!strncasecmp("bit",argv[2],3)
-      && isdigit(*(argv[2]+3))
+      && Isdigit(*(argv[2]+3))
       && sscanf(argv[2]+3, "%d%c", &bitno, &c ) == 1
       && bitno >= 0 && bitno <= STFL_HMAX)
         force_facbit(bitno,enable,als);
@@ -760,7 +760,7 @@ int archlvl_cmd(int argc, char *argv[], char *cmdline)
         char    c;
 
             if(!strncasecmp("bit",argv[2],3)
-              && isdigit(*(argv[2]+3))
+              && Isdigit(*(argv[2]+3))
               && sscanf(argv[2]+3,"%d%c",&bitno, &c) == 1
               && bitno >= 0 && bitno <= STFL_HMAX)
             {

--- a/cckddiag.c
+++ b/cckddiag.c
@@ -347,7 +347,7 @@ char               *p;
         p = s;
         if ( (*s == '0') && (*(s+1) == 'x') ) {
             s = s + 2;
-            for (v = 0; isxdigit(*s); ++s)
+            for (v = 0; Isxdigit(*s); ++s)
                 v = (v << 4) + xv[strchr(xd, *s) - xd];
             if (debug)
                 // "OFFTIFY hex string '%s' = 0x%16.16"PRIX64", dec %"PRId64"."

--- a/cgibin.c
+++ b/cgibin.c
@@ -1189,7 +1189,7 @@ void cgibin_cmd_cmd(WEBBLK *webblk, char *command)
 {
     char * response;
 
-    while (isspace(*command))
+    while (Isspace(*command))
         command++;
 
     if (*command == 0)

--- a/chsc.c
+++ b/chsc.c
@@ -741,7 +741,7 @@ BYTE dumpbuf[32*1024] = {0};
         MSGBUF( hex, "%2.2X", *p );
         strlcat(hexbuf, hex, sizeof(hexbuf));
         c = guest_to_host(*p);
-        if (!isprint(c) || iscntrl(c)) c = '.';
+        if (!Isprint(c) || Iscntrl(c)) c = '.';
         charbuf[disp & 15] = c;
     }
 

--- a/ckddasd.c
+++ b/ckddasd.c
@@ -3807,7 +3807,7 @@ BYTE            trk_ovfl;               /* == 1 if track ovfl write  */
            the key, which will usually be a dataset name or member
            name and can provide useful debugging information */
         if ((*unitstat & CSW_SM) && dev->ckdkeytrace
-            && isprint(guest_to_host(iobuf[0])))
+            && Isprint(guest_to_host(iobuf[0])))
         {
             BYTE module[45];
             str_guest_to_host( iobuf, module, (u_int)num );

--- a/cmdtab.c
+++ b/cmdtab.c
@@ -722,7 +722,7 @@ void *panel_command (void *cmdline)
     /* If the command starts with a -, then strip it and indicate
      * that we do NOT want the command echoed to the console. */
     hercecho = 1; /* (default) */
-    while (*pCmdLine && isspace( *pCmdLine ))
+    while (*pCmdLine && Isspace( *pCmdLine ))
         pCmdLine++;
     i = 0;
     while (*pCmdLine && i < (MAX_CMD_LEN-1))
@@ -737,7 +737,7 @@ void *panel_command (void *cmdline)
             {
                 pCmdLine++;         /* (skip past the '-' ... */
                                     /* ... and remove blanks) */
-                while (*pCmdLine && isspace(*pCmdLine))
+                while (*pCmdLine && Isspace(*pCmdLine))
                     pCmdLine++;     /* (get past blank) */
             }
         }

--- a/cmpsc.c
+++ b/cmpsc.c
@@ -1899,7 +1899,7 @@ static int ARCH_DEP(cmpsc_vstore)(struct ec *ec, BYTE *buf, unsigned len)
           logmsg(" ");
         else
         {
-          if(isprint(guest_to_host(buf[i + j])))
+          if(Isprint(guest_to_host(buf[i + j])))
             logmsg("%c", guest_to_host(buf[i + j]));
           else
             logmsg(".");

--- a/codepage.c
+++ b/codepage.c
@@ -1449,7 +1449,7 @@ DLL_EXPORT int update_codepage(int argc, char *argv[], char *cmd )
                     }
                     j += snprintf( hbuf+j, sizeof(hbuf)-j, "%2.2X", c );
                     if ( g_to_h) c = guest_to_host(c);
-                    cbuf[k++] = ( !isprint(c) ? '.' : c );
+                    cbuf[k++] = ( !Isprint(c) ? '.' : c );
                 } /* end for(i) */
                 WRMSG( HHC01486, "I", ( ( o >> 4 ) & 0xf ), hbuf, cbuf, ( ( o >> 4 ) & 0xf ) );
             }
@@ -1600,7 +1600,7 @@ DLL_EXPORT BYTE* prt_guest_to_host( const BYTE *psinbuf, BYTE *psoutbuf, const u
     for( count = 0; count < ilength; count++ )
     {
         c = guest_to_host(psinbuf[count]);
-        if ( !isprint(c) )
+        if ( !Isprint(c) )
             c = '.';
         psoutbuf[count] = c;
     }
@@ -1620,7 +1620,7 @@ DLL_EXPORT BYTE* prt_host_to_guest( const BYTE *psinbuf, BYTE *psoutbuf, const u
             pad = TRUE;
         if ( !pad )
         {
-            psoutbuf[count] = isprint      (psinbuf[count]) ?
+            psoutbuf[count] = Isprint      (psinbuf[count]) ?
                               host_to_guest(psinbuf[count]) :
                               host_to_guest('.');
         }

--- a/comm3705.c
+++ b/comm3705.c
@@ -293,9 +293,9 @@ packet_trace( BYTE* pAddr, int iLen )
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( Isprint( e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( Isprint( c ) )
                     print_ascii[i] = c;
             }
             else

--- a/commadpt.c
+++ b/commadpt.c
@@ -1058,7 +1058,7 @@ static void commadpt_read_tty(COMMADPT *ca, BYTE * bfr, int len)
             }
             if  (ca->uctrans && c >= 'a' && c <= 'z')
             {
-                c = toupper( c );     /* make uppercase */
+                c = Toupper( c );     /* make uppercase */
             }
             /* now map the character from ASCII into proper S/370 byte format */
             if (ca->term == COMMADPT_TERM_TTY)

--- a/con1052c.c
+++ b/con1052c.c
@@ -319,7 +319,7 @@ static void* con1052_panel_command( char *cmd )
             input = cmd + pfxlen;
 
             for (i=0; i < dev->bufsize && input[i] != '\0'; i++)
-                dev->buf[i] = isprint( input[i] ) ?
+                dev->buf[i] = Isprint( input[i] ) ?
                         host_to_guest( input[i] ) : ' ';
 
             /* Update number of bytes in keyboard buffer */
@@ -404,7 +404,7 @@ BYTE    c;                              /* Print character           */
             if (1
                 && c != 0x0d
                 && c != 0x0a
-                && !isprint(c)
+                && !Isprint(c)
             )
                 c = ' ';
             iobuf[len] = c;

--- a/config.c
+++ b/config.c
@@ -1022,7 +1022,11 @@ TID   tid;
     }
 
     /* Initialise the CPU's thread clockid so that clock_gettime() can use it */
+#if HAVE_PTHREAD_GETCPUCLOCKID
     pthread_getcpuclockid(sysblk.cputid[cpu], &sysblk.cpuclockid[cpu]);
+#else
+    sysblk.cpuclockid[cpu] = CLOCK_VIRTUAL;
+#endif
 
     /* Find out if we are a cpu thread */
     tid = thread_id();

--- a/configure.ac
+++ b/configure.ac
@@ -1145,6 +1145,7 @@ if test "$hc_cv_have_pthread_h" = "yes"; then
     CFLAGS="$CFLAGS -pthread"
     AC_CHECK_FUNCS( pthread_create ) dnl tester for method of checking...
     AC_CHECK_FUNCS( pthread_getcpuclockid )
+    AC_CHECK_FUNCS( pthread_rwlockattr_setpshared )
     CFLAGS="$save_CFLAGS"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -737,7 +737,7 @@ AC_CHECK_HEADERS( linux/ipv6.h,   [hc_cv_have_linux_ipv6_h=yes],   [hc_cv_have_l
       #include <sys/socket.h>
     #endif
 ] )
-AC_CHECK_HEADERS( net/if_var.h,   [hc_cv_have_net_in_var_h=yes],   [hc_cv_have_net_in_var_h=no],
+AC_CHECK_HEADERS( net/if_var.h,   [hc_cv_have_net_if_var_h=yes],   [hc_cv_have_net_if_var_h=no],
 [
     #include <sys/types.h>
     #ifdef HAVE_SYS_SOCKET_H

--- a/configure.ac
+++ b/configure.ac
@@ -753,8 +753,10 @@ AC_CHECK_HEADERS( netinet/in_var.h,  [hc_cv_have_netinet_in_var_h=yes],  [hc_cv_
     #ifdef HAVE_SYS_SOCKET_H
       #include <sys/socket.h>
     #endif
-    #ifdef HAVE_NET_IF_VAR_H
+    #ifdef HAVE_NET_IF_H
       #include <net/if.h>
+    #endif
+    #ifdef HAVE_NET_IF_VAR_H
       #include <net/if_var.h>
     #endif
     #ifdef HAVE_NETINET_IN_H
@@ -767,8 +769,10 @@ AC_CHECK_HEADERS( netinet6/in6_var.h,  [hc_cv_have_netinet6_in6_var_h=yes],  [hc
     #ifdef HAVE_SYS_SOCKET_H
       #include <sys/socket.h>
     #endif
-    #ifdef HAVE_NET_IF_VAR_H
+    #ifdef HAVE_NET_IF_H
       #include <net/if.h>
+    #endif
+    #ifdef HAVE_NET_IF_VAR_H
       #include <net/if_var.h>
     #endif
     #ifdef HAVE_NETINET_IN_VAR_H
@@ -1222,10 +1226,16 @@ AC_CHECK_MEMBERS( [struct in6_ifreq.ifr_ifru.ifru_flags],
     #ifdef HAVE_LINUX_IPV6_H
       #include <linux/ipv6.h>
     #endif
-    #ifdef HAVE_NETINET6_IN6_VAR_H
+    #ifdef HAVE_NET_IF_H
       #include <net/if.h>
+    #endif
+    #ifdef HAVE_NET_IF_VAR_H
       #include <net/if_var.h>
+    #endif
+    #ifdef HAVE_NETINET_IN_H
       #include <netinet/in.h>
+    #endif
+    #ifdef HAVE_NETINET6_IN6_VAR_H
       #include <netinet/in_var.h>  // Not the ipv6 file, please
     #endif
 ] )

--- a/configure.ac
+++ b/configure.ac
@@ -1140,6 +1140,13 @@ if test "$hc_cv_have_getset_uid" != "yes"; then
     )
 fi
 
+if test "$hc_cv_have_pthread_h" = "yes"; then
+    save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS -pthread"
+    AC_CHECK_FUNCS( pthread_create ) dnl tester for method of checking...
+    AC_CHECK_FUNCS( pthread_getcpuclockid )
+    CFLAGS="$save_CFLAGS"
+fi
 
 #  FIXME: Disabled because some builtin ffs seem to be causing a problem.
 #         (gcc 3.4 barfs on certain 'march=' settings?)

--- a/console.c
+++ b/console.c
@@ -930,10 +930,10 @@ static int  loc3270_init_handler( DEVBLK* dev, int argc, char* argv[] )
                 strupper( group, argv[ac] );
 
                 for (i=1, rc=0; i < (int) strlen( group ) && rc == 0; i++)
-                    if (!isalnum( group[i] ))
+                    if (!Isalnum( group[i] ))
                         rc = -1;
 
-                if (rc == 0 && isalpha( group[0] ))
+                if (rc == 0 && Isalpha( group[0] ))
                     strlcpy( dev->filename, group, sizeof( dev->filename ));
                 else
                 {
@@ -1180,7 +1180,7 @@ static struct sockaddr_in* parse_sockspec( const char* sockspec )
 
     // Convert port to number
 
-    if (isdigit( *port ))
+    if (Isdigit( *port ))
         sin->sin_port = htons( atoi( port ));
     else
     {
@@ -4218,7 +4218,7 @@ BYTE    stat;                           /* Unit status               */
             c = guest_to_host( iobuf[len] );
             /* Replace any non-printable characters with a blank
                except keep carriage returns and newlines as-is. */
-            if (!isprint(c) && c != '\r' && c!= '\n')
+            if (!Isprint(c) && c != '\r' && c!= '\n')
                 c = ' ';
             iobuf[len] = c;   /* only printable or CR/LF allowed */
         } /* end for(len) */

--- a/control.c
+++ b/control.c
@@ -7170,7 +7170,7 @@ static BYTE hexebcdic[16] = { 0xF0,0xF1,0xF2,0xF3,0xF4,0xF5,0xF6,0xF7,
         BYTE c, s[17]; int j;
         for (j=0; j<16; j++) {
             c = guest_to_host(m[j]);
-            s[j] = isprint(c) ? c : '.';
+            s[j] = Isprint(c) ? c : '.';
         }
         s[j] = '\0';
         logmsg("+%2.2X %2.2X%2.2X%2.2X%2.2X %2.2X%2.2X%2.2X%2.2X "

--- a/ctc_ctci.c
+++ b/ctc_ctci.c
@@ -1480,7 +1480,7 @@ static int  ParseArgs( DEVBLK* pDEVBLK, PCTCBLK pCTCBLK,
 
             char * s = pCTCBLK->szTUNIfName + strlen(pCTCBLK->szTUNIfName);
 
-            while(isdigit(s[- 1])) s--;
+            while(Isdigit(s[- 1])) s--;
             strlcat( pCTCBLK->szTUNCharDevName,  s, sizeof(pCTCBLK->szTUNCharDevName) );
         }
 #endif

--- a/ctc_ptp.c
+++ b/ctc_ptp.c
@@ -2917,7 +2917,7 @@ int  parse_conf_stmt( DEVBLK* pDEVBLK, PTPBLK* pPTPBLK,
 
         char * s = pPTPBLK->szTUNIfName + strlen(pPTPBLK->szTUNIfName);
 
-        while(isdigit(s[- 1])) s--;
+        while(Isdigit(s[- 1])) s--;
         strlcat( pPTPBLK->szTUNCharDevName,  s, sizeof(pPTPBLK->szTUNCharDevName) );
     }
 #endif

--- a/dasdload.c
+++ b/dasdload.c
@@ -1609,7 +1609,7 @@ char    hex[17];                        /* Character work areas      */
             }
             sprintf(hex+2*j, "%2.2X", xbuf[bufpos+offset+i]);
             c = guest_to_host(xbuf[bufpos+offset+i]);
-            if (!isprint(c)) c = '.';
+            if (!Isprint(c)) c = '.';
             chars[j] = c;
         } /* end for(i) */
         XMINFF (4, "%-16.16s %-8.8s", hex, chars);
@@ -2236,7 +2236,7 @@ char            hex[49];                /* Character work areas      */
             }
             sprintf(hex+2*j, "%2.2X", dirent->pds2usrd[i]);
             c = guest_to_host(dirent->pds2usrd[i]);
-            if (!isprint(c)) c = '.';
+            if (!Isprint(c)) c = '.';
             chars[j] = c;
         } /* end for(i) */
         if (i <= 8)

--- a/dasdutil.c
+++ b/dasdutil.c
@@ -50,7 +50,7 @@ DLL_EXPORT void string_to_upper (char *source)
 int     i;                              /* Array subscript           */
 
     for (i = 0; source[i] != '\0'; i++)
-        source[i] = toupper(source[i]);
+        source[i] = Toupper(source[i]);
 
 } /* end function string_to_upper */
 
@@ -62,7 +62,7 @@ DLL_EXPORT void string_to_lower (char *source)
 int     i;                              /* Array subscript           */
 
     for (i = 0; source[i] != '\0'; i++)
-        source[i] = tolower(source[i]);
+        source[i] = Tolower(source[i]);
 
 } /* end function string_to_lower */
 
@@ -167,9 +167,9 @@ int             lastsame = 0;
             if (offset < (U32)len) {
                 sprintf(hex_chars+xi, "%2.2X", c);
                 print_chars[i] = '.';
-                if (isprint(c)) print_chars[i] = c;
+                if (Isprint(c)) print_chars[i] = c;
                 c = guest_to_host(c);
-                if (isprint(c)) print_chars[i] = c;
+                if (Isprint(c)) print_chars[i] = c;
             }
             offset++;
             xi += 2;
@@ -544,7 +544,7 @@ char            pathname[MAX_PATH];     /* file path in host format  */
         char *p;
         for (p = rmtdev + 1; *p && *p != ':'; p++)
         {
-            if (!isdigit(*p))  /* (port numbers are always numeric) */
+            if (!Isdigit(*p))  /* (port numbers are always numeric) */
             {
                 /* Not a port number ==> not really a remote device */
                 rmtdev = NULL;
@@ -2265,7 +2265,7 @@ DLL_EXPORT int valid_dsname( const char *pszdsname )
     for ( i = 0; i < iLen; i++ )
     {
         BYTE c = pszdsname[i];
-        if ( isalnum( c ) )
+        if ( Isalnum( c ) )
             continue;
         else if ( c == '$' )
             continue;

--- a/diagnose.c
+++ b/diagnose.c
@@ -78,7 +78,7 @@ static char *prefix[] = {
     for(i = 0; i < sizeof(name)-1; i++)
     {
         name[i] = guest_to_host(name[i]);
-        if(!isprint(name[i]) || isspace(name[i]))
+        if(!Isprint(name[i]) || Isspace(name[i]))
         {
             name[i] = '\0';
             break;

--- a/dmap2hrc.c
+++ b/dmap2hrc.c
@@ -181,7 +181,7 @@ char            pathname[MAX_PATH];     /* file path in host format  */
            locate the output filename. */
         strncpy(output_type, device.type, 4);
         output_type[4] = '\0';
-        if (isprint(device.parms.disk.volser[0]))
+        if (Isprint(device.parms.disk.volser[0]))
             output_filename = device.parms.disk.filename;
         else output_filename = device.parms.other.filename;
 

--- a/hao.c
+++ b/hao.c
@@ -690,8 +690,8 @@ static void hao_message(char *buf)
             continue;
           }
           /* replace $1..$99 by the corresponding capturing group */
-          if (*p == '$' && isdigit(p[1])) {
-            if (isdigit(p[2])) {
+          if (*p == '$' && Isdigit(p[1])) {
+            if (Isdigit(p[2])) {
               j = (p[1]-'0') * 10 + (p[2]-'0');
               k = 3;
             } else {

--- a/hdl.c
+++ b/hdl.c
@@ -304,8 +304,8 @@ size_t       m;
     strlcat(dtname,ltype,m);
 
     for(n = 0; n < strlen(dtname); n++)
-        if(isupper(dtname[n]))
-            dtname[n] = tolower(dtname[n]);
+        if(Isupper(dtname[n]))
+            dtname[n] = Tolower(dtname[n]);
 
     return dtname;
 }

--- a/hercifc.c
+++ b/hercifc.c
@@ -110,7 +110,7 @@ int main( int argc, char **argv )
 
         switch( ctlreq.iCtlOp )
         {
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
         case TUNSETIFF:
             pOp  = "TUNSETIFF";
             pArg = &ctlreq.iru.hifr.ifreq;

--- a/hetinit.c
+++ b/hetinit.c
@@ -45,7 +45,7 @@ void het_string_to_upper (char *source)
 int i;
 
     for (i = 0; source[i] != '\0'; i++)
-        source[i] = toupper(source[i]);
+        source[i] = Toupper(source[i]);
 }
 
 /*

--- a/hetmap.c
+++ b/hetmap.c
@@ -666,7 +666,7 @@ Print_Standard_Labels (void )
     TERMINATE(lLblType);
     TERMINATE(lLblNum);
 
-    if ( isdigit( lLblNum[0] ) )
+    if ( Isdigit( lLblNum[0] ) )
     { if ( lLblNum[0] < '1' || lLblNum[0] > '9' ) return ( FALSE ); } /* this should be transportable to EBCDIC machines */
     else
         return ( FALSE );
@@ -757,7 +757,7 @@ Print_Standard_Labels (void )
 
                     if ( lLblType[0] == 'E' )
                     {
-                        for ( i = 0; i < 4; i++ ) { if ( !isdigit( ebcnt[i] ) ) ebcnt[i] = '0'; }
+                        for ( i = 0; i < 4; i++ ) { if ( !Isdigit( ebcnt[i] ) ) ebcnt[i] = '0'; }
                         ebcnt[4] = '\0';
                     }
                     else

--- a/hifr.h
+++ b/hifr.h
@@ -109,7 +109,7 @@ struct hifr
 };
 typedef struct hifr hifr;
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__SOLARIS__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__SOLARIS__) || defined (__NetBSD__)
   #define  hifr_name       ifreq.ifr_name
 #else
   #define  hifr_name       ifreq.ifr_ifrn.ifrn_name

--- a/hostopts.h
+++ b/hostopts.h
@@ -311,6 +311,30 @@
 
 
 /*-------------------------------------------------------------------*/
+/* Hard-coded NetBSD-specific features and options...                */
+/*-------------------------------------------------------------------*/
+#elif defined(__NetBSD__)               /* "NetBSD" options          */
+
+#define DLL_IMPORT   extern
+#define DLL_EXPORT
+#define TUNTAP_IFF_RUNNING_NEEDED       /* Needed by tuntap driver?? */
+#undef  OPTION_SCSI_ERASE_TAPE          /* (NOT supported)           */
+#undef  OPTION_SCSI_ERASE_GAP           /* (NOT supported)           */
+#define MAX_DEVICE_THREADS          0   /* (0 == unlimited)          */
+#define MIXEDCASE_FILENAMES_ARE_UNIQUE  /* ("Foo" and "fOo" unique)  */
+#define DEFAULT_HERCPRIO    0
+#define DEFAULT_TOD_PRIO  -20
+#define DEFAULT_CPU_PRIO   15
+#define DEFAULT_DEV_PRIO    8
+#define DEFAULT_SRV_PRIO    4
+#define HOW_TO_IMPLEMENT_SH_COMMAND       USE_ANSI_SYSTEM_API_FOR_SH_COMMAND
+#define SET_CONSOLE_CURSOR_SHAPE_METHOD   CURSOR_SHAPE_NOT_SUPPORTED
+#undef  OPTION_EXTCURS                  /* Normal cursor handling    */
+#define SCANDIR_CONST_STRUCT_DIRENT     /* define if scandir uses
+                                           const for struct dirent   */
+
+
+/*-------------------------------------------------------------------*/
 /* Hard-coded GNU Linux-specific features and options...             */
 /*-------------------------------------------------------------------*/
 #elif defined(__gnu_linux__)            /* GNU Linux options         */

--- a/hsccmd.c
+++ b/hsccmd.c
@@ -3056,7 +3056,7 @@ char *strtok_str = NULL;
         for (cpu = 0; styp != NULL; )
         {
             count = 1;
-            if (isdigit(styp[0]))
+            if (Isdigit(styp[0]))
             {
                 if (0
                     || sscanf(styp, "%d%c", &count, &c) != 2
@@ -3423,7 +3423,7 @@ BYTE    f = ' ', c = '\0';
 
         if ( rc == 2 )
         {
-            switch (toupper(f))
+            switch (Toupper(f))
             {
             case 'B':
                 overflow = 0;
@@ -3583,7 +3583,7 @@ u_int   locktype = 0;
                                                             : sizeof(U32);
         if ( rc == 2 )
         {
-            switch (toupper(f))
+            switch (Toupper(f))
             {
             case 'B':
                 shiftsize >>= SHIFT_MEBIBYTE;
@@ -4234,7 +4234,7 @@ int cnslport_cmd(int argc, char *argv[], char *cmdline)
 
         for (i=0; i < (int) strlen( port ); i++)
         {
-            if (!isdigit(port[i]))
+            if (!Isdigit(port[i]))
             {
                 // "Invalid value %s specified for %s"
                 WRMSG( HHC01451, "E", port, argv[0] );
@@ -4522,7 +4522,7 @@ int sh_cmd(int argc, char *argv[], char *cmdline)
     if (sysblk.shcmdopt & SHCMDOPT_ENABLE)
     {
         cmd = cmdline + 2;
-        while (isspace(*cmd)) cmd++;
+        while (Isspace(*cmd)) cmd++;
         if (*cmd)
         {
             rc = herc_system(cmd);
@@ -4587,7 +4587,7 @@ int cd_cmd(int argc, char *argv[], char *cmdline)
     if (sysblk.shcmdopt & SHCMDOPT_ENABLE)
     {
         path = cmdline + 2;
-        while (isspace(*path)) path++;
+        while (Isspace(*path)) path++;
 #ifdef _MSVC_
         {
             char* strtok_str = NULL;
@@ -4993,7 +4993,7 @@ int stsi_model_cmd(int argc, char *argv[], char *cmdline)
             {
                 for (i=0; i < len; i++)
                 {
-                    if (!isalnum(model[m][i]))
+                    if (!Isalnum(model[m][i]))
                     {
                         char msgbuf[64];
 
@@ -5069,7 +5069,7 @@ int stsi_plant_cmd(int argc, char *argv[], char *cmdline)
 
         for ( i = 0; i < strlen(argv[1]); i++ )
         {
-            if ( isalnum(argv[1][i]) )
+            if ( Isalnum(argv[1][i]) )
                 continue;
             WRMSG( HHC02205, "E", argv[1], "; argument contains invalid characters" );
             return -1;
@@ -5120,7 +5120,7 @@ int stsi_manufacturer_cmd(int argc, char *argv[], char *cmdline)
 
         for ( i = 0; i < strlen(argv[1]); i++ )
         {
-            if ( isalnum(argv[1][i]) )
+            if ( Isalnum(argv[1][i]) )
                 continue;
 
             WRMSG( HHC02205, "E", argv[1], "; argument contains invalid characters" );
@@ -5743,8 +5743,8 @@ int devlist_cmd(int argc, char *argv[], char *cmdline)
             int i;
             strlcpy( devtype, argv[1], sizeof(devtype) );
             for ( i = 0; i < (int)strlen( devtype ); i++ )
-                if ( isalpha( devtype[i] ) )
-                    devtype[i] = toupper( devtype[i] );
+                if ( Isalpha( devtype[i] ) )
+                    devtype[i] = Toupper( devtype[i] );
         }
     }
 
@@ -6117,7 +6117,7 @@ int qd_cmd(int argc, char *argv[], char *cmdline)
                 if (j%4 == 0)
                     len += sprintf(buf + len, " ");
                 len += sprintf(buf + len, "%2.2X", iobuf[j]);
-                cbuf[j%16] = isprint(guest_to_host(iobuf[j])) ? guest_to_host(iobuf[j]) : '.';
+                cbuf[j%16] = Isprint(guest_to_host(iobuf[j])) ? guest_to_host(iobuf[j]) : '.';
             }
             len += sprintf(buf + len, " |%s|", cbuf);
             WRMSG(HHC02280, "I", buf);
@@ -6826,7 +6826,7 @@ BYTE     unitstat, code = 0;
     {
         for (rc = 0; rc < (int)strlen(argv[3]); rc++)
         {
-            if ( !isdigit(argv[3][rc]) )
+            if ( !Isdigit(argv[3][rc]) )
             {
                 WRMSG( HHC02205, "E", argv[3], "; not in range of 1-9999");
                 return -1;
@@ -7473,7 +7473,7 @@ int defsym_cmd(int argc, char *argv[], char *cmdline)
     {
         int i;
         for ( i = 0; sym[i] != '\0'; i++ )
-            sym[i] = toupper( sym[i] );
+            sym[i] = Toupper( sym[i] );
     }
 #endif
 
@@ -7544,7 +7544,7 @@ int delsym_cmd(int argc, char *argv[], char *cmdline)
     {
         int i;
         for ( i = 0; sym[i] != '\0'; i++ )
-            sym[i] = toupper( sym[i] );
+            sym[i] = Toupper( sym[i] );
     }
 #endif
 

--- a/hscloc.c
+++ b/hscloc.c
@@ -95,7 +95,7 @@ void fmt_line( unsigned char *tbl, char *name, int start, int length)
             if ( (i & 0xf) == 0x0 ) { hbuf[j++] = SPACE; cbuf[k++] = SPACE; }
 
             j += snprintf( hbuf+j, sizeof(hbuf)-j, "%2.2X", c );
-            cbuf[k++] = ( !isprint(c) ? '.' : c );
+            cbuf[k++] = ( !Isprint(c) ? '.' : c );
 
         } /* end for(i) */
         MSGBUF( fmtline, "%s+0x%04x%-74.74s %-34.34s", name, o, hbuf, cbuf );

--- a/hscmisc.c
+++ b/hscmisc.c
@@ -818,7 +818,7 @@ BYTE    c;                              /* Character work area       */
             h1 = *(++s);
             if (h1 == '\0'  || h1 == '#' ) break;
             if (h1 == SPACE || h1 == '\t') continue;
-            h1 = toupper(h1);
+            h1 = Toupper(h1);
             h1 = (h1 >= '0' && h1 <= '9') ? h1 - '0' :
                  (h1 >= 'A' && h1 <= 'F') ? h1 - 'A' + 10 : -1;
             if (h1 < 0)
@@ -827,7 +827,7 @@ BYTE    c;                              /* Character work area       */
                 return -1;
             }
             h2 = *(++s);
-            h2 = toupper(h2);
+            h2 = Toupper(h2);
             h2 = (h2 >= '0' && h2 <= '9') ? h2 - '0' :
                  (h2 >= 'A' && h2 <= 'F') ? h2 - 'A' + 10 : -1;
             if (h2 < 0)
@@ -1456,7 +1456,7 @@ static void TrimEnd( char* buf )
 {
     size_t n; char* p;
 
-    for (n = strlen(buf), p = buf+n-1; p > buf && isspace((BYTE)*p); --p, --n)
+    for (n = strlen(buf), p = buf+n-1; p > buf && Isspace((BYTE)*p); --p, --n)
         ; // (nop)
     p[1] = 0;
 }
@@ -1919,7 +1919,7 @@ BYTE    c;                              /* Character work area       */
         j += snprintf (hbuf+j, sizeof(hbuf)-j, "%2.2X", c);
         if ((aaddr & 0x3) == 0x0) hbuf[j++] = SPACE;
         c = guest_to_host(c);
-        if (!isprint(c)) c = '.';
+        if (!Isprint(c)) c = '.';
         cbuf[i] = c;
         if ((aaddr & PAGEFRAME_BYTEMASK) == 0x000) break;
     } /* end for(i) */
@@ -2097,7 +2097,7 @@ char    buf[512];                       /* MSGBUF work buffer        */
 
     /* Parse optional address-space prefix */
     opnd = argv[0];
-    type = toupper( *opnd );
+    type = Toupper( *opnd );
 
     if (0
         || type == 'R'
@@ -2226,7 +2226,7 @@ char    absorr[8];                      /* Uppercase command         */
 
     /* Convert command to uppercase */
     for (i = 0; argv[0][i]; i++)
-        absorr[i] = toupper(argv[0][i]);
+        absorr[i] = Toupper(argv[0][i]);
     absorr[i] = 0;
     opnd = argv[1];
 
@@ -2389,7 +2389,7 @@ size_t  totamt;                         /* Total amount to be dumped */
 
     /* Parse optional address-space prefix */
     opnd = argv[0];
-    type = toupper( *opnd );
+    type = Toupper( *opnd );
 
     if (1
         && type != 'P'

--- a/hscpufun.c
+++ b/hscpufun.c
@@ -426,9 +426,9 @@ int  rest_loadparm = FALSE;
                 }
                 for ( j = 0; j < (int)strlen(argv[i]) && maxb < MAXPARMSTRING; j++ )
                 {
-                    if ( islower(argv[i][j]) )
+                    if ( Islower(argv[i][j]) )
                     {
-                        argv[i][j]=toupper(argv[i][j]);
+                        argv[i][j]=Toupper(argv[i][j]);
                     }
                     sysblk.iplparmstring[maxb]=host_to_guest(argv[i][j]);
                     maxb++;

--- a/hscutl.c
+++ b/hscutl.c
@@ -495,7 +495,7 @@ DLL_EXPORT char *resolve_symbol_string(const char *text)
             if (c == '\0' ) break;
 
             /* Check if it is a white space and no other character yet */
-            if(!lstarted && isspace(c)) continue;
+            if(!lstarted && Isspace(c)) continue;
             lstarted=1;
 
             /* Check that statement does not overflow buffer */

--- a/hstdinc.h
+++ b/hstdinc.h
@@ -92,6 +92,17 @@
 #include <string.h>
 #include <setjmp.h>
 #include <ctype.h>
+#define Isspace(c)	isspace((int)(unsigned char)(c))
+#define Isprint(c)	isprint((int)(unsigned char)(c))
+#define Isdigit(c)	isdigit((int)(unsigned char)(c))
+#define Isxdigit(c)	isxdigit((int)(unsigned char)(c))
+#define Iscntrl(c)	iscntrl((int)(unsigned char)(c))
+#define Isalnum(c)	isalnum((int)(unsigned char)(c))
+#define Isalpha(c)	isalpha((int)(unsigned char)(c))
+#define Isupper(c)	isupper((int)(unsigned char)(c))
+#define Islower(c)	islower((int)(unsigned char)(c))
+#define Toupper(c)	toupper((int)(unsigned char)(c))
+#define Tolower(c)	tolower((int)(unsigned char)(c))
 #include <errno.h>
 #include <fcntl.h>
 #ifndef O_BINARY

--- a/hthreads.h
+++ b/hthreads.h
@@ -178,7 +178,11 @@ typedef pthread_rwlock_t        HRWLOCK;
 #define hthread_mutex_destroy( plk )            pthread_mutex_destroy( plk )
 
 #define hthread_rwlockattr_init( pla )          pthread_rwlockattr_init( pla )
+#if HAVE_PTHREAD_RWLOCKATTR_SETPSHARED
 #define hthread_rwlockattr_setpshared( pla, s ) pthread_rwlockattr_setpshared( (pla), (s) )
+#else
+#define hthread_rwlockattr_setpshared( pla, s ) 0
+#endif
 #define hthread_rwlockattr_destroy( pla )       pthread_rwlockattr_destroy( pla )
 
 #define hthread_rwlock_init( plk, pla )         pthread_rwlock_init( (plk), (pla) )

--- a/httpserv.c
+++ b/httpserv.c
@@ -355,7 +355,7 @@ static void http_verify_path(WEBBLK *webblk, char *path)
     int i;
 
     for (i = 0; path[i]; i++)
-        if (!isalnum((int)path[i]) && !strchr("/.-_", path[i]))
+        if (!Isalnum((int)path[i]) && !strchr("/.-_", path[i]))
             http_error(webblk, "404 File Not Found","",
                                "Illegal character in filename");
 #endif

--- a/impl.c
+++ b/impl.c
@@ -1306,9 +1306,9 @@ int     c = 0;                        /* Next option flag            */
                     {
                     int j;
                         for( j = 0; j < (int)strlen( sym ); j++ )
-                            if ( islower( sym[j] ) )
+                            if ( Islower( sym[j] ) )
                             {
-                                sym[j] = toupper( sym[j] );
+                                sym[j] = Toupper( sym[j] );
                             }
                         set_symbol(sym, value);
                     }
@@ -1387,7 +1387,7 @@ int     c = 0;                        /* Next option flag            */
         default:
             {
                 char buf[16];
-                if (isprint( optopt ))
+                if (Isprint( optopt ))
                     MSGBUF( buf, "'-%c'", optopt );
                 else
                     MSGBUF( buf, "(hex %2.2x)", optopt );

--- a/loadparm.c
+++ b/loadparm.c
@@ -100,8 +100,8 @@ static GSYSINFO gsysinfo;
     if (_source) \
         { \
         for (; i < n; i++) \
-             if (isprint(_source[i])) \
-                 _target[i] = host_to_guest((int)toupper(_source[i])); \
+             if (Isprint(_source[i])) \
+                 _target[i] = host_to_guest((int)Toupper(_source[i])); \
              else \
                  _target[i] = 0x40; \
         } \
@@ -119,9 +119,9 @@ static GSYSINFO gsysinfo;
     BYTE    temp[sizeof(_target)]; \
     memset(temp, 0x40, sizeof(temp) ); \
     for (i = 0, n = 0; name && i < strlen(name) && i < sizeof(temp); i++) \
-        if (isalnum(name[i])) \
+        if (Isalnum(name[i])) \
         { \
-            temp[i] = host_to_guest((int)toupper(name[i])); \
+            temp[i] = host_to_guest((int)Toupper(name[i])); \
             n++; \
         } \
         else \
@@ -183,9 +183,9 @@ static int copy_stringz_to_ebcdic(BYTE* fld, size_t len, char *name)
     copylen = MIN(strlen(name), len);
 
     for ( i = 0, n = 0; i < copylen; i++ )
-        if ( isalnum(name[i]) )
+        if ( Isalnum(name[i]) )
         {
-            temp_fld[i] = host_to_guest((int)toupper(name[i]));
+            temp_fld[i] = host_to_guest((int)Toupper(name[i]));
             n++;
         }
         else
@@ -220,7 +220,7 @@ static int copy_ebcdic_to_stringz(char *name, size_t nlen, BYTE* fld, size_t fle
     {
         c = guest_to_host(fld[i]);
 
-        if ( c == SPACE || !isalnum(c) )
+        if ( c == SPACE || !Isalnum(c) )
             break; /* there should not be any embedded blanks */
 
         name[i] = c;

--- a/ltdl.c
+++ b/ltdl.c
@@ -65,6 +65,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 
 #if HAVE_CTYPE_H
 #  include <ctype.h>
+#  define Isspace(c)	isspace((int)(unsigned char)(c))
+#  define Isalnum(c)	isalnum((int)(unsigned char)(c))
 #endif
 
 #if HAVE_MALLOC_H
@@ -2859,10 +2861,10 @@ UNREFERENCED(deplibs);
   p = deplibs;
   while (*p)
     {
-      if (!isspace ((int) *p))
+      if (!Isspace (*p))
     {
       char *end = p+1;
-      while (*end && !isspace((int) *end))
+      while (*end && !Isspace(*end))
         {
           ++end;
         }
@@ -2911,14 +2913,14 @@ UNREFERENCED(deplibs);
   p = deplibs;
   while (*p)
     {
-      if (isspace ((int) *p))
+      if (Isspace (*p))
     {
       ++p;
     }
       else
     {
       char *end = p+1;
-      while (*end && !isspace ((int) *end))
+      while (*end && !Isspace (*end))
         {
           ++end;
         }
@@ -3160,7 +3162,7 @@ try_dlopen (phandle, filename)
         size_t i;
         for (i = 0; i < (unsigned int)(ext - base_name); ++i)
       {
-        if (isalnum ((int)(base_name[i])))
+        if (Isalnum(base_name[i]))
           {
             name[i] = base_name[i];
           }

--- a/mpc.c
+++ b/mpc.c
@@ -183,9 +183,9 @@ DLL_EXPORT void  mpc_display_stuff( DEVBLK* pDEVBLK, char* cWhat, BYTE* pAddr, i
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( Isprint( e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( Isprint( c ) )
                     print_ascii[i] = c;
             }
             else

--- a/omatape.c
+++ b/omatape.c
@@ -211,7 +211,7 @@ char           *strtok_str = NULL;      /* last token position       */
                 tdffilenm[i] = '/';
 /* JCS */
 //            else
-//                tdffilenm[i] = tolower(tdffilenm[i]);
+//                tdffilenm[i] = Tolower(tdffilenm[i]);
         } /* end for(i) */
 
         /* Prefix the file name with the base path name and

--- a/panel.c
+++ b/panel.c
@@ -1476,7 +1476,7 @@ static void NP_update(REGS *regs)
                 l = (int)strlen(devnam);
                 for ( p = 0; p < l; p++ )
                 {
-                    if ( !isprint(devnam[p]) )
+                    if ( !Isprint(devnam[p]) )
                     {
                         devnam[p] = '\0';
                         break;
@@ -2040,7 +2040,7 @@ size_t  loopcount;                    /* Number of iterations done   */
                         case 1:                     /* IPL - 2nd part */
                             if (!sysblk.hicpu)
                               break;
-                            i = toupper(NPdevice) - 'A';
+                            i = Toupper(NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2061,7 +2061,7 @@ size_t  loopcount;                    /* Number of iterations done   */
                         case 2:                     /* Device int: part 2 */
                             if (!sysblk.hicpu)
                               break;
-                            i = toupper(NPdevice) - 'A';
+                            i = Toupper(NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2080,7 +2080,7 @@ size_t  loopcount;                    /* Number of iterations done   */
                             redraw_status = 1;
                             break;
                         case 3:                     /* Device asgn: part 2 */
-                            i = toupper(NPdevice) - 'A';
+                            i = Toupper(NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2291,13 +2291,13 @@ size_t  loopcount;                    /* Number of iterations done   */
 
                             while (*p && ncmd_tok < 10 )
                             {
-                                while (*p && isspace(*p)) p++; if (!*p) break; // find start of arg
+                                while (*p && Isspace(*p)) p++; if (!*p) break; // find start of arg
 
                                 if (*p == '#') break; // stop on comments
 
                                 cmd_tok[ncmd_tok] = p; ++ncmd_tok; // count new arg
 
-                                while ( *p && !isspace(*p) &&
+                                while ( *p && !Isspace(*p) &&
                                         *p != '\"' && *p != '\'' ) p++; if (!*p) break; // find end of arg
 
                                 if (*p == '\"' || *p == '\'')
@@ -2374,7 +2374,7 @@ size_t  loopcount;                    /* Number of iterations done   */
                                             }
                                         }
                                     }
-                                    else if ( !isdigit( pt1[idx+1] ) && ( pt1[idx+1] != '$' ) )
+                                    else if ( !Isdigit( pt1[idx+1] ) && ( pt1[idx+1] != '$' ) )
                                     {
                                         psz_cmdline[odx++] = pt1[idx];
                                     }
@@ -2750,7 +2750,7 @@ size_t  loopcount;                    /* Number of iterations done   */
                 } /* end if (kbbuf[i] == '\n') */
 
                 /* Ignore non-printable characters */
-                if (!isprint(kbbuf[i])) {
+                if (!Isprint(kbbuf[i])) {
                     beep();
                     i++;
                     continue;

--- a/printer.c
+++ b/printer.c
@@ -103,7 +103,7 @@ do { \
     for (i = 0; i < num; i++) \
     { \
         c = guest_to_host(iobuf[i]); \
-        if (dev->fold) c = toupper(c); \
+        if (dev->fold) c = Toupper(c); \
         if (c == 0) c = SPACE; \
         dev->buf[dev->bufoff] = c; \
         dev->bufoff++; \

--- a/qeth.c
+++ b/qeth.c
@@ -3876,7 +3876,7 @@ U32 mask4;
         {
             // Check whether a numeric prefix in the range 1 to 128 has been specified.
             rc = 0;
-            for (p = grp->ttpfxlen6; isdigit(*p); p++) { }
+            for (p = grp->ttpfxlen6; Isdigit(*p); p++) { }
             if (*p != '\0' || !strlen(grp->ttpfxlen6))
                 rc = -1;
             pfxlen = atoi(grp->ttpfxlen6);
@@ -6108,7 +6108,7 @@ static int  prefix2netmask( char* ttpfxlen, char** ttnetmask )
     char* p;
     int pfxlen;
     /* make sure it's a number from 0 to 32 */
-    for (p = ttpfxlen; isdigit(*p); p++) { }
+    for (p = ttpfxlen; Isdigit(*p); p++) { }
     if (*p || !ttpfxlen[0] || (pfxlen = atoi(ttpfxlen)) > 32)
         return -1;
     addr4.s_addr = ~makepfxmask4( ttpfxlen );

--- a/scescsi.c
+++ b/scescsi.c
@@ -718,7 +718,7 @@ int n;
 
         if(!(!ntf->name
           && !strncasecmp("type",argv[1],4)
-          && isdigit(*(argv[1]+4))
+          && Isdigit(*(argv[1]+4))
           && sscanf(argv[1]+4, "%u%c", &file, &c) == 1
           && file < HWL_MAXFILETYPE))
         {
@@ -769,7 +769,7 @@ int  ldind;  /* Load / Dump indicator */
 
     UNREFERENCED(cmdline);
 
-    ldind = ((islower(*argv[0]) ? toupper(*argv[0]) : *argv[0] ) == 'L')
+    ldind = ((Islower(*argv[0]) ? Toupper(*argv[0]) : *argv[0] ) == 'L')
           ? 0 : 1;
 
     if(argc > 1)

--- a/script.c
+++ b/script.c
@@ -100,13 +100,13 @@ DLL_EXPORT int parse_args (char* p, int maxargc, char** pargv, int* pargc)
 
     while (*p && *pargc < maxargc)
     {
-        while (*p && isspace(*p)) p++; if (!*p) break; // find start of arg
+        while (*p && Isspace(*p)) p++; if (!*p) break; // find start of arg
 
         if (*p == '#' && *pargc) break; // stop when line comment reached
 
         *pargv = p; ++*pargc; // count new arg
 
-        while (*p && !isspace(*p) && *p != '\"' && *p != '\'') p++; if (!*p) break; // find end of arg
+        while (*p && !Isspace(*p) && *p != '\"' && *p != '\'') p++; if (!*p) break; // find end of arg
 
         if (*p == '\"' || *p == '\'')
         {
@@ -174,7 +174,7 @@ char   *buf1;                           /* Pointer to resolved buffer*/
             if (c == '\0' || c == '\r') continue;
 
             /* Check if it is a white space and no other character yet */
-            if(!lstarted && isspace(c)) continue;
+            if(!lstarted && Isspace(c)) continue;
             lstarted=1;
 
             /* Check that statement does not overflow buffer */
@@ -895,7 +895,7 @@ int     rc;                             /* (work)                    */
 #if defined(ENABLE_OBJECT_REXX) || defined(ENABLE_REGINA_REXX)
 
     /* Skip past blanks to start of command */
-    for (p = stmt; isspace( *p ); p++)
+    for (p = stmt; Isspace( *p ); p++)
         ; /* (nop; do nothing) */
 
     /* Execute REXX script if line begins with "Slash '/' Asterisk '*'" */
@@ -917,11 +917,11 @@ int     rc;                             /* (work)                    */
         stmtnum++;
 
         /* Skip past blanks to start of statement */
-        for (p = stmt; isspace( *p ); p++)
+        for (p = stmt; Isspace( *p ); p++)
             ; /* (nop; do nothing) */
 
         /* Remove trailing whitespace */
-        for (stmtlen = (int)strlen(p); stmtlen && isspace(p[stmtlen-1]); stmtlen--);
+        for (stmtlen = (int)strlen(p); stmtlen && Isspace(p[stmtlen-1]); stmtlen--);
         p[stmtlen] = 0;
 
         /* Special handling for 'pause' and other statements */
@@ -1141,7 +1141,7 @@ int runtest( SCRCTL *pCtl, char *cmdline, char *args )
             args = p2;
 #endif
 
-        if (isalpha( args[0] ))  /* [RESTART|START|<oldpsw>]? */
+        if (Isalpha( args[0] ))  /* [RESTART|START|<oldpsw>]? */
         {
 #define MAX_KW_LEN 15
             char kw[ MAX_KW_LEN + 1 ] = {0};

--- a/service.c
+++ b/service.c
@@ -1573,7 +1573,7 @@ BYTE            *xstmap;                /* Xstore bitmap, zero means
                         {
                             for (i = 0; i < event_msglen; i++)
                             {
-                                message[i] = isprint(guest_to_host(event_msg[i])) ?
+                                message[i] = Isprint(guest_to_host(event_msg[i])) ?
                                     guest_to_host(event_msg[i]) : 0x20;
                             }
                             message[i] = '\0';

--- a/sllib.c
+++ b/sllib.c
@@ -1157,13 +1157,13 @@ sl_ds1( SLLABEL *lab,
         gdg  = 0;
         gdg += (          dsn[ len - 9 ]   == '.' );
         gdg += (          dsn[ len - 8 ]   == 'G' );
-        gdg += ( isdigit( dsn[ len - 7 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 6 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 5 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 4 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 7 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 6 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 5 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 4 ] ) !=  0  );
         gdg += (          dsn[ len - 3 ]   == 'V' );
-        gdg += ( isdigit( dsn[ len - 2 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 1 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 2 ] ) !=  0  );
+        gdg += ( Isdigit( dsn[ len - 1 ] ) !=  0  );
 
         if( gdg == 9 )
         {

--- a/sockdev.c
+++ b/sockdev.c
@@ -164,7 +164,7 @@ int inet_socket (char* spec)
         memcpy(&sin.sin_addr, he->h_addr_list[0], sizeof(sin.sin_addr));
     }
 
-    if (isdigit(service[0]))
+    if (Isdigit(service[0]))
     {
         sin.sin_port = htons(atoi(service));
     }

--- a/sr.c
+++ b/sr.c
@@ -448,7 +448,7 @@ int      numconfdev=0;
             if (len >= 2)
             {
                 len -= 2;
-                while (len > 0 && isspace(buf[len]))
+                while (len > 0 && Isspace(buf[len]))
                     --len;
                 buf[len+1]=0;
             }

--- a/tapedev.c
+++ b/tapedev.c
@@ -1529,7 +1529,7 @@ int  mountnewtape ( DEVBLK *dev, int argc, char **argv )
                 }
                 else if ( rc == 2 )
                 {
-                    switch (toupper(f))
+                    switch (Toupper(f))
                     {
                         case 'K':
                             maxsize <<= SHIFT_KIBIBYTE;
@@ -1592,7 +1592,7 @@ int  mountnewtape ( DEVBLK *dev, int argc, char **argv )
                 }
                 else if ( rc == 2 )
                 {
-                    switch (toupper(f))
+                    switch (Toupper(f))
                     {
                         case 'K':
                             eotmargin <<= SHIFT_KIBIBYTE;

--- a/tuntap.c
+++ b/tuntap.c
@@ -1223,8 +1223,8 @@ int  ParseMAC( char* pszMACAddr, BYTE* pbMACAddr )
     {
         if
         (0
-            || !isxdigit(work[(i*3)+0])
-            || !isxdigit(work[(i*3)+1])
+            || !Isxdigit(work[(i*3)+0])
+            || !Isxdigit(work[(i*3)+1])
             ||  sep  !=  work[(i*3)+2]
         )
         {
@@ -1337,9 +1337,9 @@ void net_data_trace( DEVBLK* pDEVBLK, BYTE* pAddr, int iLen, BYTE bDir, BYTE bSe
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( Isprint( e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( Isprint( c ) )
                     print_ascii[i] = c;
             }
             else

--- a/vm.c
+++ b/vm.c
@@ -984,7 +984,7 @@ BYTE       c;                           /* Character work area       */
     for (i = 0; i < 8; i++)
     {
         c = (*puser == '\0' ? SPACE : *(puser++));
-        buf[16+i] = host_to_guest(toupper(c));
+        buf[16+i] = host_to_guest(Toupper(c));
     }
 
     /* Bytes 24-31 contain the program product bitmap */
@@ -1109,10 +1109,10 @@ char    msgbuf[512];                    /* Message work area         */
         int shcmd = 0;
         {
             char* p = bufo;
-            while (*p && isspace(*p)) p++;
+            while (*p && Isspace(*p)) p++;
             if ((*(p+0) == 's' || *(p+0) == 'S') &&
                 (*(p+1) == 'h' || *(p+1) == 'H') &&
-                isspace(*(p+2))) shcmd = 1;
+                Isspace(*(p+2))) shcmd = 1;
         }
         if ((sysblk.diag8cmd & DIAG8CMD_ENABLE)
             && (!shcmd || (sysblk.shcmdopt & (SHCMDOPT_ENABLE + SHCMDOPT_DIAG8)))

--- a/vmfplc2.c
+++ b/vmfplc2.c
@@ -230,7 +230,7 @@ char *validate_cmsfile(char *fn,char *ft,char *fm)
         sprintf(msg,"Invalid character in CMS file type at position %d",i);
         return msg;
     }
-    if(!isalpha(fm[0]))
+    if(!Isalpha(fm[0]))
     {
         return "CMS File mode must start with a letter";
     }
@@ -260,7 +260,7 @@ void str_toupper(char *s)
 
     for(i=0;s[i];i++)
     {
-        if(islower(s[i])) s[i]=toupper(s[i]);
+        if(Islower(s[i])) s[i]=Toupper(s[i]);
     }
 }
 

--- a/w32ctca.c
+++ b/w32ctca.c
@@ -119,7 +119,7 @@ void __cdecl tt32_output_debug_string( const char* debug_string )
         *p2 && (nl2 = nl = strchr( p2, '\n' )); p2 = nl+1)
     {
         // Remove trailing whitespace to conform to Hercules logmsg format.
-        for (; nl2 >= p2 && isspace(*nl2); --nl2)
+        for (; nl2 >= p2 && Isspace(*nl2); --nl2)
             *nl2 = 0;
         if (*p2)
             // "DBG: %s"

--- a/w32stape.c
+++ b/w32stape.c
@@ -202,7 +202,7 @@ ufd_t w32_open_tape ( const char* path, int oflag, ... )
                     strnfilenamecmp( (pszTapeDevNum=path+7)-2, "st",  2 ) == 0
                 )
             &&  strlen(pszTapeDevNum) == 1
-            &&  isdigit(*pszTapeDevNum)
+            &&  Isdigit(*pszTapeDevNum)
         )
         {
             // Change it to a Windows device name (e.g. \\.\Tape0)

--- a/w32util.c
+++ b/w32util.c
@@ -194,7 +194,7 @@ DLL_EXPORT char* w32_w32errmsg( int errnum, char* pszBuffer, size_t nBuffSize )
     // (remove trailing whitespace)
     {
         char* p = pszBuffer + dwBytesReturned - 1;
-        while ( p >= pszBuffer && isspace(*p) ) p--;
+        while ( p >= pszBuffer && Isspace(*p) ) p--;
         *++p = 0;
     }
 
@@ -1470,7 +1470,7 @@ DLL_EXPORT BYTE *hostpath( BYTE *outpath, const BYTE *inpath, size_t buffsize )
         if (1
             && inlen >= 11
             && strncasecmp((const char *)inpath,"/cygdrive/",10) == 0
-            && isalpha(inpath[10])
+            && Isalpha(inpath[10])
         )
         {
             *outpath++ = inpath[10];
@@ -4334,7 +4334,7 @@ DLL_EXPORT pid_t w32_poor_mans_fork ( char* pszCommandLine, int* pnWriteToChildS
 
         // Now print ALL captured messages AT ONCE (if any)...
 
-        while (pPipedProcessCtl->nStrLen && isspace( pPipedProcessCtl->pszBuffer[ pPipedProcessCtl->nStrLen - 1 ] ))
+        while (pPipedProcessCtl->nStrLen && Isspace( pPipedProcessCtl->pszBuffer[ pPipedProcessCtl->nStrLen - 1 ] ))
             pPipedProcessCtl->nStrLen--;
         if (pPipedProcessCtl->nStrLen)
         {
@@ -4483,7 +4483,7 @@ void w32_parse_piped_process_stdxxx_data ( PIPED_PROCESS_CTL* pPipedProcessCtl, 
         *pend = 0;                      // (change newline character to null)
         pmsgend = pend;                 // (start removing blanks from here)
 
-        while (--pmsgend >= pbeg && isspace(*pmsgend)) {*pmsgend = 0; --nlen;}
+        while (--pmsgend >= pbeg && Isspace(*pmsgend)) {*pmsgend = 0; --nlen;}
 
         // If we were passed a PIPED_PROCESS_CTL pointer, then the root thread
         // wants us to just capture the o/p and IT will issue the logmsg within
@@ -4659,10 +4659,10 @@ DLL_EXPORT char*  w32_strcasestr( const char* haystack, const char* needle )
 
     while ( haystack[++i] != '\0' )
     {
-        if ( tolower( haystack[i] ) == tolower( needle[0] ) )
+        if ( Tolower( haystack[i] ) == Tolower( needle[0] ) )
         {
             int j=i, k=0, match=0;
-            while ( tolower( haystack[++j] ) == tolower( needle[++k] ) )
+            while ( Tolower( haystack[++j] ) == Tolower( needle[++k] ) )
             {
                 match=1;
                 // Catch case when they match at the end


### PR DESCRIPTION
These changes will allow hyperion to build on NetBSD. I have not seriously tested the executable yet but it starts.
The last of the changes is an attempt to get rid of one of the many many many warning messages that gcc 4.8.4 produces. Because of them you can't find any serious issues, so I got rid of one class (but there are more, the one that seems most common now are  printf format warnings).